### PR TITLE
fix: missing the REPO_MANAGEMENT_TOKEN variable 

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -6,7 +6,7 @@ on:
     types:
       - completed
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.REPO_MANAGEMENT_TOKEN }}
 jobs:
   generate_changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-auto-assign.yaml
+++ b/.github/workflows/pr-auto-assign.yaml
@@ -6,8 +6,7 @@ on:
     types: [opened, edited, labeled, unlabeled]
 jobs:
   run:
-    runs-on:
-      group: custom-runners
+    runs-on: ubuntu-latest
     steps:
       - uses: wow-actions/auto-assign@v3
         with:

--- a/.github/workflows/pr-auto-assign.yaml
+++ b/.github/workflows/pr-auto-assign.yaml
@@ -4,13 +4,16 @@ on:
     types: [opened, edited, labeled, unlabeled]
   pull_request:
     types: [opened, edited, labeled, unlabeled]
+env:
+  GITHUB_TOKEN: ${{ secrets.REPO_MANAGEMENT_TOKEN }}
+
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
       - uses: wow-actions/auto-assign@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
           reviewers: |
             apetrovYa
           skipKeywords: wip

--- a/.github/workflows/tag-and-docker-build-and-push.yaml
+++ b/.github/workflows/tag-and-docker-build-and-push.yaml
@@ -33,7 +33,7 @@ jobs:
         id: bump-version-and-push-tag
         uses: anothrNick/github-tag-action@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: patch
       - name: Set up QEMU

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -18,7 +18,7 @@ import logger from './logger';
 export default class ApplicationManifest {
     program = new Command();
     name = 'helm-packager';
-    version = '1.0.0';
+    version = '0.0.1';
     description =
         'A command line utility to manufacture OCI formatted Helm charts';
     commands = [


### PR DESCRIPTION
# Description

This PR fixes the permissions for the workflow `tag-and-docker-build-and-push` to create and push a tag in the repository.

This PR will release patch version of the tool.